### PR TITLE
Fix reserved-id-macro warnings

### DIFF
--- a/SFconv/ushort_chartraits.h
+++ b/SFconv/ushort_chartraits.h
@@ -1,5 +1,4 @@
-#ifndef ushort_chartraits_h
-#define ushort_chartraits_h
+#pragma once
 
 #include <iostream>
 #include <string>
@@ -98,5 +97,3 @@ namespace std
       { return eq_int_type(__c, eof()) ? int_type(0) : __c; }
     };
 }
-
-#endif /* ushort_chartraits_h */

--- a/SFconv/ushort_chartraits.h
+++ b/SFconv/ushort_chartraits.h
@@ -1,5 +1,5 @@
-#ifndef __ushort_chartraits_h__
-#define __ushort_chartraits_h__
+#ifndef ushort_chartraits_h
+#define ushort_chartraits_h
 
 #include <iostream>
 #include <string>
@@ -99,4 +99,4 @@ namespace std
     };
 }
 
-#endif
+#endif /* ushort_chartraits_h */

--- a/source/Compiler.h
+++ b/source/Compiler.h
@@ -20,8 +20,7 @@ Changes:
 
 -------------------------------------------------------------------------*/
 
-#ifndef Compiler_H
-#define Compiler_H
+#pragma once
 
 #ifdef HAVE_CONFIG_H
 #	include "config.h"	/* a Unix-ish setup where we have config.h available */
@@ -345,5 +344,3 @@ extern "C" {
 	};
 	extern CharName	gUnicodeNames[];
 }
-
-#endif	/* Compiler_H */

--- a/source/Compiler.h
+++ b/source/Compiler.h
@@ -20,8 +20,8 @@ Changes:
 
 -------------------------------------------------------------------------*/
 
-#ifndef __Compiler_H__
-#define __Compiler_H__
+#ifndef Compiler_H
+#define Compiler_H
 
 #ifdef HAVE_CONFIG_H
 #	include "config.h"	/* a Unix-ish setup where we have config.h available */
@@ -346,4 +346,4 @@ extern "C" {
 	extern CharName	gUnicodeNames[];
 }
 
-#endif	/* __Compiler_H__ */
+#endif	/* Compiler_H */

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -17,8 +17,8 @@ Description:
 	2003-09-23	jk	updated for version 2.1 with new Opt APIs
 */
 
-#ifndef __Engine_H__
-#define __Engine_H__
+#ifndef Engine_H
+#define Engine_H
 
 #include "TECkit_Engine.h"
 #include "TECkit_Format.h"
@@ -221,4 +221,4 @@ protected:
 	UInt32				warningStatus;
 };
 
-#endif /* __Engine_H__ */
+#endif /* Engine_H */

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -17,8 +17,7 @@ Description:
 	2003-09-23	jk	updated for version 2.1 with new Opt APIs
 */
 
-#ifndef Engine_H
-#define Engine_H
+#pragma once
 
 #include "TECkit_Engine.h"
 #include "TECkit_Format.h"
@@ -220,5 +219,3 @@ protected:
 	
 	UInt32				warningStatus;
 };
-
-#endif /* Engine_H */

--- a/source/Public-headers/TECkit_Common.h
+++ b/source/Public-headers/TECkit_Common.h
@@ -23,8 +23,7 @@ History:
 	xx-xxx-2002		jk	version 2.0 initial release
 */
 
-#ifndef TECkit_Common_H
-#define TECkit_Common_H
+#pragma once
 
 #define	kCurrentTECkitVersion	0x00020004	/* 16.16 version number */
 
@@ -91,5 +90,3 @@ typedef long					TECkit_Status;
 #define kForm_UTF16LE				4
 #define kForm_UTF32BE				5
 #define kForm_UTF32LE				6
-
-#endif /* TECkit_Common_H */

--- a/source/Public-headers/TECkit_Common.h
+++ b/source/Public-headers/TECkit_Common.h
@@ -23,8 +23,8 @@ History:
 	xx-xxx-2002		jk	version 2.0 initial release
 */
 
-#ifndef __TECkit_Common_H__
-#define __TECkit_Common_H__
+#ifndef TECkit_Common_H
+#define TECkit_Common_H
 
 #define	kCurrentTECkitVersion	0x00020004	/* 16.16 version number */
 
@@ -92,4 +92,4 @@ typedef long					TECkit_Status;
 #define kForm_UTF32BE				5
 #define kForm_UTF32LE				6
 
-#endif
+#endif /* TECkit_Common_H */

--- a/source/Public-headers/TECkit_Compiler.h
+++ b/source/Public-headers/TECkit_Compiler.h
@@ -18,8 +18,8 @@
 	Copyright (c) 2002-2016 SIL International.
 */
 
-#ifndef __TECkit_Compiler_H__
-#define __TECkit_Compiler_H__
+#ifndef TECkit_Compiler_H
+#define TECkit_Compiler_H
 
 #include "TECkit_Common.h"
 
@@ -96,4 +96,4 @@ TECkit_GetUnicodeValue(char* name);
 }
 #endif
 
-#endif
+#endif /* TECkit_Compiler_H */

--- a/source/Public-headers/TECkit_Compiler.h
+++ b/source/Public-headers/TECkit_Compiler.h
@@ -18,8 +18,7 @@
 	Copyright (c) 2002-2016 SIL International.
 */
 
-#ifndef TECkit_Compiler_H
-#define TECkit_Compiler_H
+#pragma once
 
 #include "TECkit_Common.h"
 
@@ -95,5 +94,3 @@ TECkit_GetUnicodeValue(char* name);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* TECkit_Compiler_H */

--- a/source/Public-headers/TECkit_Engine.h
+++ b/source/Public-headers/TECkit_Engine.h
@@ -26,8 +26,8 @@ Description:
 	22-Dec-2001		jk	initial version
 */
 
-#ifndef __TECkit_Engine_H__
-#define __TECkit_Engine_H__
+#ifndef TECkit_Engine_H
+#define TECkit_Engine_H
 
 #include "TECkit_Common.h"
 
@@ -265,4 +265,4 @@ TECkit_FlushOpt(
 }	/* extern "C" */
 #endif
 
-#endif /* __TECkit_Engine_H__ */
+#endif /* TECkit_Engine_H */

--- a/source/Public-headers/TECkit_Engine.h
+++ b/source/Public-headers/TECkit_Engine.h
@@ -26,8 +26,7 @@ Description:
 	22-Dec-2001		jk	initial version
 */
 
-#ifndef TECkit_Engine_H
-#define TECkit_Engine_H
+#pragma once
 
 #include "TECkit_Common.h"
 
@@ -264,5 +263,3 @@ TECkit_FlushOpt(
 #if defined(__cplusplus)
 }	/* extern "C" */
 #endif
-
-#endif /* TECkit_Engine_H */

--- a/source/TECkit_Format.h
+++ b/source/TECkit_Format.h
@@ -14,8 +14,7 @@ Description:
 	2006-06-02	jk	added support for extended string rules (>255 per initial char)
 -------------------------------------------------------------------------*/
 
-#ifndef TECkit_Format_H
-#define TECkit_Format_H
+#pragma once
 
 #include "TECkit_Common.h"
 
@@ -217,5 +216,3 @@ typedef union RepElem			RepElem;
 #define kRepElem_Class				kMatchElem_Type_Class
 #define kRepElem_Copy				kMatchElem_Type_Copy
 #define kRepElem_Unmapped			0x0f	/* used in default terminator rules */
-
-#endif	/* TECkit_Format_H */

--- a/source/TECkit_Format.h
+++ b/source/TECkit_Format.h
@@ -14,8 +14,8 @@ Description:
 	2006-06-02	jk	added support for extended string rules (>255 per initial char)
 -------------------------------------------------------------------------*/
 
-#ifndef __TECkit_Format_H__
-#define __TECkit_Format_H__
+#ifndef TECkit_Format_H
+#define TECkit_Format_H
 
 #include "TECkit_Common.h"
 
@@ -218,4 +218,4 @@ typedef union RepElem			RepElem;
 #define kRepElem_Copy				kMatchElem_Type_Copy
 #define kRepElem_Unmapped			0x0f	/* used in default terminator rules */
 
-#endif	/* __TECkit_Format_H__ */
+#endif	/* TECkit_Format_H */

--- a/source/teckitjni/src/TecKitJni.h
+++ b/source/teckitjni/src/TecKitJni.h
@@ -13,10 +13,9 @@ Description:
     Implements a JNI interface to the TECkit conversion engine.
 -------------------------------------------------------------------------*/
 
-#ifndef TecKitJni_h
-#define TecKitJni_h
-#include "TECkit_Engine.h"
+#pragma once
 
+#include "TECkit_Engine.h"
 
 class TecKitJni
 {
@@ -40,5 +39,3 @@ private:
     char * inputBuffer;
     UInt32 maxInputLength;
 };
-
-#endif

--- a/source/ulong_chartraits.h
+++ b/source/ulong_chartraits.h
@@ -1,5 +1,4 @@
-#ifndef ulong_chartraits_h
-#define ulong_chartraits_h
+#pragma once
 
 #include <iostream>
 #include <string>
@@ -105,5 +104,3 @@ namespace std
       { return eq_int_type(__c, eof()) ? int_type(0) : __c; }
     };
 }
-
-#endif /* ulong_chartraits_h */

--- a/source/ulong_chartraits.h
+++ b/source/ulong_chartraits.h
@@ -1,5 +1,5 @@
-#ifndef __ulong_chartraits_h__
-#define __ulong_chartraits_h__
+#ifndef ulong_chartraits_h
+#define ulong_chartraits_h
 
 #include <iostream>
 #include <string>
@@ -106,4 +106,4 @@ namespace std
     };
 }
 
-#endif
+#endif /* ulong_chartraits_h */


### PR DESCRIPTION
These warnings were found with `clang` and the following:

```
$ ./configure CXXFLAGS="-Werror -Wreserved-id-macro"
```