### PR TITLE
Add basic .travis.yml for testing on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: cpp
+
+matrix:
+  include:
+    - os: linux
+    - os: osx
+
+script:
+  - ./autogen.sh
+  - ./configure
+  - make
+  - sudo make install
+  - cd test; ./dotests.pl


### PR DESCRIPTION
This is a basic script for configuring, building, and testing on [Travis-CI](https://travis-ci.org/). In case you're not aware, Travis-CI provides free continuous-integration testing for open-source software. I've used it many times, and it can be very helpful to keep your code working. You can see this script run successfully [here](https://travis-ci.org/spl/teckit/builds/447656103).

To have this run, you will need to create a Travis-CI account, which you can do using your GitHub account. You will also need to flick a switch on the Travis-CI settings for this repository to enable it. The default setting is to run on every pull request and commit.

This script performs the simplest configuration, build, installation, and test run on Ubuntu Linux and macOS. There is plenty more you could extend this with in the future. I can imagine, for example, testing against multiple compiler versions and building install packages. Unfortunately, Travis-CI does not support Microsoft WIndows: there are other services for that, but I haven't used them.