### PR TITLE
Fix old-style-cast warnings

### DIFF
--- a/SFconv/sfReader.h
+++ b/SFconv/sfReader.h
@@ -9,9 +9,9 @@
 #define INLINE_START	2
 #define INLINE_END		3
 #define INLINE_MARKER	4
-#define UNI_REPLACEMENT_CHAR    (uint32_t)0x0000FFFD
-#define UNI_MAX_BMP             (uint32_t)0x0000FFFF
-#define UNI_MAX_UTF16           (uint32_t)0x0010FFFF
+#define UNI_REPLACEMENT_CHAR    static_cast<uint32_t>(0x0000FFFD)
+#define UNI_MAX_BMP             static_cast<uint32_t>(0x0000FFFF)
+#define UNI_MAX_UTF16           static_cast<uint32_t>(0x0010FFFF)
 
 template<class C>
 class sfReader

--- a/SFconv/sfReader.h
+++ b/SFconv/sfReader.h
@@ -9,9 +9,9 @@
 #define INLINE_START	2
 #define INLINE_END		3
 #define INLINE_MARKER	4
-#define UNI_REPLACEMENT_CHAR    static_cast<uint32_t>(0x0000FFFD)
-#define UNI_MAX_BMP             static_cast<uint32_t>(0x0000FFFF)
-#define UNI_MAX_UTF16           static_cast<uint32_t>(0x0010FFFF)
+#define UNI_REPLACEMENT_CHAR    uint32_t(0x0000FFFD)
+#define UNI_MAX_BMP             uint32_t(0x0000FFFF)
+#define UNI_MAX_UTF16           uint32_t(0x0010FFFF)
 
 template<class C>
 class sfReader

--- a/SFconv/ushort_chartraits.h
+++ b/SFconv/ushort_chartraits.h
@@ -91,7 +91,7 @@ namespace std
       { return __c1 == __c2; }
 
       static int_type 
-      eof() { return static_cast<int_type>(-1); }
+      eof() { return int_type(-1); }
 
       static int_type 
       not_eof(const int_type& __c)

--- a/SFconv/ushort_chartraits.h
+++ b/SFconv/ushort_chartraits.h
@@ -65,11 +65,11 @@ namespace std
 
       static char_type* 
       move(char_type* __s1, const char_type* __s2, size_t __n)
-      { return (char_type*) memmove(__s1, __s2, __n * sizeof(char_type)); }
+      { return static_cast<char_type*>(memmove(__s1, __s2, __n * sizeof(char_type))); }
 
       static char_type* 
       copy(char_type* __s1, const char_type* __s2, size_t __n)
-      { return (char_type*) memcpy(__s1, __s2, __n * sizeof(char_type)); }
+      { return static_cast<char_type*>(memcpy(__s1, __s2, __n * sizeof(char_type))); }
 
       static char_type* 
       assign(char_type* __s, size_t __n, char_type __a)

--- a/source/Compiler.cpp
+++ b/source/Compiler.cpp
@@ -189,14 +189,14 @@ TECkit_DisposeCompiled(Byte* table)
 		free(table);
 }
 
-const char*
+char*
 WINAPI
 TECkit_GetUnicodeName(UInt32 usv)
 {
 	const CharName	*c = &gUnicodeNames[0];
 	while (c->name != 0)
 		if (c->usv == usv)
-			return c->name;
+			return const_cast<char*>(c->name);
 		else
 			++c;
 	return NULL;
@@ -2133,7 +2133,7 @@ Compiler::Error(const char* msg, const char* s, UInt32 line)
 		cout << " at line " << line << endl;
 	}
 	else
-		(*errorFunction)(errFuncUserData, msg, s, line);
+		(*errorFunction)(errFuncUserData, const_cast<char*>(msg), const_cast<char*>(s), line);
 	errorState = true;
 	++errorCount;
 }

--- a/source/Compiler.cpp
+++ b/source/Compiler.cpp
@@ -189,14 +189,14 @@ TECkit_DisposeCompiled(Byte* table)
 		free(table);
 }
 
-char*
+const char*
 WINAPI
 TECkit_GetUnicodeName(UInt32 usv)
 {
 	const CharName	*c = &gUnicodeNames[0];
 	while (c->name != 0)
 		if (c->usv == usv)
-			return const_cast<char*>(c->name);
+			return c->name;
 		else
 			++c;
 	return NULL;
@@ -2133,7 +2133,7 @@ Compiler::Error(const char* msg, const char* s, UInt32 line)
 		cout << " at line " << line << endl;
 	}
 	else
-		(*errorFunction)(errFuncUserData, const_cast<char*>(msg), const_cast<char*>(s), line);
+		(*errorFunction)(errFuncUserData, msg, s, line);
 	errorState = true;
 	++errorCount;
 }

--- a/source/Compiler.cpp
+++ b/source/Compiler.cpp
@@ -75,7 +75,7 @@ const UInt32 kSurrogateLowStart		= 0xDC00UL;
 const UInt32 byteMask				= 0x000000BFUL;
 const UInt32 byteMark				= 0x00000080UL;
 
-#define FOUR_CHAR_CODE(a,b,c,d)	(UInt32)((a << 24) + (b << 16) + (c << 8) + d)
+#define FOUR_CHAR_CODE(a,b,c,d)	static_cast<UInt32>((a << 24) + (b << 16) + (c << 8) + d)
 
 const UInt32 kCode_Byte	= FOUR_CHAR_CODE('B','y','t','e');
 const UInt32 kCode_BU	= FOUR_CHAR_CODE('B','-','>','U');
@@ -142,7 +142,7 @@ TECkit_Compile(char* txt, UInt32 len, Byte doCompression, TECkit_ErrorFn errFunc
 {
 	TECkit_Status	result = kStatus_CompilationFailed;
 	try {
-		Compiler*	cmp = new Compiler(txt, len, kForm_Unspecified, (bool)doCompression, false, errFunc, userData);
+		Compiler*	cmp = new Compiler(txt, len, kForm_Unspecified, static_cast<bool>(doCompression), false, errFunc, userData);
 		cmp->GetCompiledTable(*outTable, *outLen);
 		if (*outTable == 0)
 			result = kStatus_CompilationFailed;
@@ -196,7 +196,7 @@ TECkit_GetUnicodeName(UInt32 usv)
 	const CharName	*c = &gUnicodeNames[0];
 	while (c->name != 0)
 		if (c->usv == usv)
-			return (char*)c->name;
+			return const_cast<char*>(c->name);
 		else
 			++c;
 	return NULL;
@@ -524,7 +524,7 @@ Compiler::Compiler(const char* txt, UInt32 len, char inForm, bool cmp, bool genX
 	compiledSize = 0;
 	usedExtStringRules = false;
 
-	textPtr = (const unsigned char*)txt;
+	textPtr = reinterpret_cast<const unsigned char*>(txt);
 	textEnd = textPtr + len;
 	
 	ungotten = kInvalidChar;
@@ -628,7 +628,7 @@ Compiler::Compiler(const char* txt, UInt32 len, char inForm, bool cmp, bool genX
 		errorState = false;
 
 		string32::const_iterator i;
-		switch ((int)tok.type) {
+		switch (static_cast<int>(tok.type)) {
 			default:
 				Error("this can't happen!");
 				break;
@@ -771,7 +771,7 @@ Compiler::Compiler(const char* txt, UInt32 len, char inForm, bool cmp, bool genX
 			case '^':
 				// negation can only apply to a few things:
 				GetNextToken();
-				switch ((int)tok.type) {
+				switch (static_cast<int>(tok.type)) {
 					case tok_Number:
 						AppendLiteral(tok.val, true);
 						break;
@@ -1129,7 +1129,7 @@ Compiler::Compiler(const char* txt, UInt32 len, char inForm, bool cmp, bool genX
 					bool	ellipsisOK = false;
 					while (tok.type != ')' && tok.type != tok_Newline) {
 						GetNextToken();
-						switch ((int)tok.type) {
+						switch (static_cast<int>(tok.type)) {
 							case tok_USV:
 								if (classType == 'B') {
 									Error("can't use Unicode value in byte encoding");
@@ -1250,7 +1250,7 @@ Compiler::Compiler(const char* txt, UInt32 len, char inForm, bool cmp, bool genX
 								break;
 
 							default:
-								Error("unexpected token within class", string((const char*)tokStart, (const char*)textPtr - (const char*)tokStart).c_str());
+								Error("unexpected token within class", string(reinterpret_cast<const char *>(tokStart), reinterpret_cast<const char *>(textPtr) - reinterpret_cast<const char *>(tokStart)).c_str());
 								break;
 						}
 					}
@@ -1339,7 +1339,7 @@ Compiler::Compiler(const char* txt, UInt32 len, char inForm, bool cmp, bool genX
 			string	trailer("</teckitMapping>\n");
 			
 			compiledSize = header.length() + xmlRepresentation.length() + trailer.length();
-			compiledTable = (Byte*)malloc(compiledSize + 1);
+			compiledTable = static_cast<Byte*>(malloc(compiledSize + 1));
 			if (compiledTable == NULL)
 				throw bad_alloc();
 			
@@ -1378,30 +1378,30 @@ Compiler::Compiler(const char* txt, UInt32 len, char inForm, bool cmp, bool genX
 			// pack all the name records
 			string	namesData;
 			for (vector<UInt16>::const_iterator i = nameIDs.begin(); i != nameIDs.end(); ++i) {
-				appendToTable(offsets, (const char*)&offset, sizeof(offset));
+				appendToTable(offsets, reinterpret_cast<const char*>(&offset), sizeof(offset));
 				NameRec	r;
 				WRITE(r.nameID, *i);
 				WRITE(r.nameLength, names[*i].length());
-				namesData.append((const char*)&r, sizeof(r));
+				namesData.append(reinterpret_cast<const char*>(&r), sizeof(r));
 				namesData.append(names[*i]);
 				if ((namesData.length() & 1) != 0)
-					namesData.append(1, (char)0);
+					namesData.append(1, '\0');
 				offset += namesData.length() - prevLength;
 				prevLength = namesData.length();
 			}
 			if ((namesData.length() & 2) != 0)
-				namesData.append(2, (char)0);
+				namesData.append(2, '\0');
 			offset += namesData.length() - prevLength;
 			
 			// pack the offsets to the actual mapping tables
 			vector<string>::const_iterator t;
 			for (t = fwdTables.begin(); t != fwdTables.end(); ++t) {
-				appendToTable(offsets, (const char*)&offset, sizeof(offset));
+				appendToTable(offsets, reinterpret_cast<const char*>(&offset), sizeof(offset));
 				offset += t->size();
 			}
 			for (t = revTables.end(); t != revTables.begin(); ) {
 				--t;
-				appendToTable(offsets, (const char*)&offset, sizeof(offset));
+				appendToTable(offsets, reinterpret_cast<const char*>(&offset), sizeof(offset));
 				offset += t->size();
 			}
 			
@@ -1417,9 +1417,9 @@ Compiler::Compiler(const char* txt, UInt32 len, char inForm, bool cmp, bool genX
 				for (t = revTables.begin(); t != revTables.end(); ++t)
 					compiledSize += t->length();
 	
-				compiledTable = (Byte*)malloc(compiledSize);
+				compiledTable = static_cast<Byte*>(malloc(compiledSize));
 				if (compiledTable != 0) {
-					char*	cp = (char*)compiledTable;
+					Byte*	cp = compiledTable;
 					memcpy(cp, &fh, sizeof(fh));
 					cp += sizeof(fh);
 					memcpy(cp, offsets.data(), offsets.length());
@@ -1435,7 +1435,7 @@ Compiler::Compiler(const char* txt, UInt32 len, char inForm, bool cmp, bool genX
 						memcpy(cp, t->data(), t->length());
 						cp += t->length();
 					}
-					if ((char*)compiledTable + compiledSize != cp)
+					if (compiledTable + compiledSize != cp)
 						cerr << "error!" << endl;
 				}
 				else
@@ -1445,14 +1445,14 @@ Compiler::Compiler(const char* txt, UInt32 len, char inForm, bool cmp, bool genX
 			if (errorCount == 0 && cmp) {
 				// do the compression...
 				unsigned long	destLen = compiledSize * 11 / 10 + 20;
-				Byte*	dest = (Byte*)malloc(destLen + 8);
+				Byte*	dest = static_cast<Byte*>(malloc(destLen + 8));
 				if (dest != 0) {
 					int	result = compress2(dest + 8, &destLen, compiledTable, compiledSize, Z_BEST_COMPRESSION);
 					if (result == Z_OK) {
 						destLen += 8;
-						dest = (Byte*)realloc(dest, destLen); // shrink dest to fit
-						WRITE(((FileHeader*)dest)->type, kMagicNumberCmp);
-						WRITE(((FileHeader*)dest)->version, compiledSize);
+						dest = static_cast<Byte*>(realloc(dest, destLen)); // shrink dest to fit
+						WRITE(reinterpret_cast<FileHeader*>(dest)->type, kMagicNumberCmp);
+						WRITE(reinterpret_cast<FileHeader*>(dest)->version, compiledSize);
 						free(compiledTable);
 						compiledTable = dest;
 						compiledSize = destLen;
@@ -1500,7 +1500,7 @@ Compiler::asUTF8(const string32 s)
 		} else {					bytesToWrite = 2;
 									c = 0x0000fffd;
 		};
-		rval.append((size_t)bytesToWrite, 0);
+		rval.append(static_cast<size_t>(bytesToWrite), 0);
 		int index = rval.length();
 		switch (bytesToWrite) {	/* note: code falls through cases! */
 			case 4:	rval[--index] = (c | byteMark) & byteMask; c >>= 6;
@@ -1946,11 +1946,11 @@ Compiler::GetNextToken()
 			case '/':
 			case '=':
 			case '@':
-				tok.type = (tokenType)currCh;
+				tok.type = static_cast<tokenType>(currCh);
 				return true;
 	
 			case '<':
-				tok.type = (tokenType)'<';
+				tok.type = static_cast<tokenType>('<');
 				if (textPtr < textEnd) {
 					if ((currCh = getChar()) == '>')
 						tok.type = tok_Map;
@@ -1960,7 +1960,7 @@ Compiler::GetNextToken()
 				return true;
 	
 			case '.':
-				tok.type = (tokenType)'.';
+				tok.type = static_cast<tokenType>('.');
 				if (textPtr < textEnd) {
 					if ((currCh = getChar()) == '.')
 						tok.type = tok_Ellipsis;
@@ -1978,7 +1978,7 @@ Compiler::GetNextToken()
 						goto DEFAULT;
 					}
 				}
-				tok.type = (tokenType)'_';
+				tok.type = static_cast<tokenType>('_');
 				return true;
 			
 			case '0':
@@ -2133,7 +2133,7 @@ Compiler::Error(const char* msg, const char* s, UInt32 line)
 		cout << " at line " << line << endl;
 	}
 	else
-		(*errorFunction)(errFuncUserData, (char*)msg, (char*)s, line);
+		(*errorFunction)(errFuncUserData, const_cast<char*>(msg), const_cast<char*>(s), line);
 	errorState = true;
 	++errorCount;
 }
@@ -2577,7 +2577,7 @@ Compiler::calcMaxOutLen(Rule& rule)
 				continue;
 			
 			default:
-				cerr << "bad rep elem type: " << (int)i->type << endl;
+				cerr << "bad rep elem type: " << i->type << endl;
 				break;
 		}
 	}
@@ -2997,8 +2997,7 @@ Compiler::appendMatchElem(string& packedRule, Item& item, int index,
 			WRITE(m.flags.type, READ(m.flags.type) | (kMatchElem_NonLit + kMatchElem_Type_EOS));
 			break;
 	}
-	const char*	p = (const char*)&m;
-	packedRule.append(p, sizeof(m));
+	packedRule.append(reinterpret_cast<const char*>(&m), sizeof(m));
 }
 
 void
@@ -3039,8 +3038,7 @@ Compiler::appendReplaceElem(string& packedRule, Item& item, vector<Item>& matchS
 			WRITE(r.flags.type, kRepElem_Unmapped);
 			break;
 	}
-	const char*	p = (const char*)&r;
-	packedRule.append(p, sizeof(r));
+	packedRule.append(reinterpret_cast<const char*>(&r), sizeof(r));
 }
 
 vector<Compiler::Item>
@@ -3069,19 +3067,19 @@ Compiler::addToCharMap(UInt32 ch, UInt16 index)
 	UInt8	page = (ch & 0x00ffff) >> 8;
 	if (buildVars.planeMap.size() <= plane)
 		buildVars.planeMap.resize(plane + 1, 0xff);
-	if ((UInt8)buildVars.planeMap[plane] == (UInt8)0xff) {
+	if (static_cast<UInt8>(buildVars.planeMap[plane]) == 0xff) {
 		buildVars.planeMap[plane] = buildVars.pageMaps.size();
 		buildVars.pageMaps.resize(buildVars.pageMaps.size() + 1);
 		buildVars.pageMaps.back().resize(256, 0xff);
 	}
 	UInt8	planeIndex = buildVars.planeMap[plane];
 	string&	pageMap = buildVars.pageMaps[planeIndex];
-	if ((UInt8)pageMap[page] == (UInt8)0xff) {
+	if (static_cast<UInt8>(pageMap[page]) == 0xff) {
 		pageMap[page] = buildVars.charMaps.size();
 		buildVars.charMaps.resize(buildVars.charMaps.size() + 1);
 		buildVars.charMaps.back().resize(256);
 	}
-	vector<UInt16>&	charMap = buildVars.charMaps[(UInt8)pageMap[page]];
+	vector<UInt16>&	charMap = buildVars.charMaps[static_cast<UInt8>(pageMap[page])];
 	charMap[ch & 0x0000ff] = index;
 }
 
@@ -3307,7 +3305,7 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 							
 							case kMatchElem_Type_Copy:
 								// should only occur in UU table
-								if (t > (int)rule.matchStr.size()) {
+								if (t > static_cast<int>(rule.matchStr.size())) {
 									Error("no corresponding item for copy", 0, rule.lineNumber);
 									goto ERR_FOUND;
 								}
@@ -3338,7 +3336,7 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 									break;
 
 								case kMatchElem_Type_Class:
-									if (t > (int)rule.matchStr.size()) {
+									if (t > static_cast<int>(rule.matchStr.size())) {
 										Error("no corresponding item for class replacement", 0, rule.lineNumber);
 										goto ERR_FOUND;
 									}
@@ -3370,7 +3368,7 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 
 								case kMatchElem_Type_Copy:
 									// should only occur in BB table
-									if (t > (int)rule.matchStr.size()) {
+									if (t > static_cast<int>(rule.matchStr.size())) {
 										Error("no corresponding item for copy", 0, rule.lineNumber);
 										goto ERR_FOUND;
 									}
@@ -3455,7 +3453,7 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 		currentPass.supplementaryChars = true;
 
 	UInt32	headerOffset = table.size();
-	table.append((const char*)&th, sizeof(th));
+	table.append(reinterpret_cast<const char*>(&th), sizeof(th));
 
 	if (fromUni) {
 		WRITE(th.pageBase, table.size());
@@ -3464,13 +3462,13 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 			buildVars.planeMap.resize(17, 0xff);
 			for (i = 0; i < buildVars.planeMap.size(); ++i)
 				appendToTable(table, buildVars.planeMap[i]);
-			appendToTable(table, (UInt8)buildVars.pageMaps.size());
+			appendToTable(table, static_cast<UInt8>(buildVars.pageMaps.size()));
 			align(table, 4);
 		}
 
 		for (i = 0; i < buildVars.pageMaps.size(); ++i)
 			for (j = 0; j < buildVars.pageMaps[i].size(); ++j)
-				appendToTable(table, (UInt8)buildVars.pageMaps[i][j]);
+				appendToTable(table, static_cast<UInt8>(buildVars.pageMaps[i][j]));
 		align(table, 4);
 
 		for (i = 0; i < buildVars.charMaps.size(); ++i)
@@ -3515,17 +3513,17 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 						sortedClass.erase(sortedClass.begin() + j);
 			}
 
-			appendToTable(classes, (UInt32)sortedClass.size());
+			appendToTable(classes, static_cast<UInt32>(sortedClass.size()));
 			if (fromUni)
 				if (currentPass.supplementaryChars)
 					for (Class::iterator x = sortedClass.begin(); x != sortedClass.end(); ++x)
 						appendToTable(classes, *x);
 				else
 					for (Class::iterator x = sortedClass.begin(); x != sortedClass.end(); ++x)
-						appendToTable(classes, (UInt16)*x);
+						appendToTable(classes, static_cast<UInt16>(*x));
 			else
 				for (Class::iterator x = sortedClass.begin(); x != sortedClass.end(); ++x)
-					appendToTable(classes, (UInt8)*x);
+					appendToTable(classes, static_cast<UInt8>(*x));
 			align(classes, 4);
 		}
 		// copy the real classOffsets into the table
@@ -3563,17 +3561,17 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 						sortedClass.erase(sortedClass.begin() + j);
 			}
 
-			appendToTable(classes, (UInt32)sortedClass.size());
+			appendToTable(classes, static_cast<UInt32>(sortedClass.size()));
 			if (toUni)
 				if (currentPass.supplementaryChars)
 					for (vector<Member>::iterator x = sortedClass.begin(); x != sortedClass.end(); ++x)
 						appendToTable(classes, x->value);
 				else
 					for (vector<Member>::iterator x = sortedClass.begin(); x != sortedClass.end(); ++x)
-						appendToTable(classes, (UInt16)x->value);
+						appendToTable(classes, static_cast<UInt16>(x->value));
 			else
 				for (vector<Member>::iterator x = sortedClass.begin(); x != sortedClass.end(); ++x)
-					appendToTable(classes, (UInt8)(x->value));
+					appendToTable(classes, static_cast<UInt8>(x->value));
 			align(classes, 4);
 		}
 		// copy the real classOffsets into the table
@@ -3588,7 +3586,7 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 	if (currentPass.supplementaryChars)
 		WRITE(th.flags, READ(th.flags) | kTableFlags_Supplementary);
 	WRITE(th.length, table.size());
-	table.replace(0, sizeof(th), (const char*)&th, sizeof(th));
+	table.replace(0, sizeof(th), reinterpret_cast<const char*>(&th), sizeof(th));
 }
 
 void

--- a/source/Compiler.cpp
+++ b/source/Compiler.cpp
@@ -75,7 +75,7 @@ const UInt32 kSurrogateLowStart		= 0xDC00UL;
 const UInt32 byteMask				= 0x000000BFUL;
 const UInt32 byteMark				= 0x00000080UL;
 
-#define FOUR_CHAR_CODE(a,b,c,d)	static_cast<UInt32>((a << 24) + (b << 16) + (c << 8) + d)
+#define FOUR_CHAR_CODE(a,b,c,d)	UInt32((a << 24) + (b << 16) + (c << 8) + d)
 
 const UInt32 kCode_Byte	= FOUR_CHAR_CODE('B','y','t','e');
 const UInt32 kCode_BU	= FOUR_CHAR_CODE('B','-','>','U');
@@ -142,7 +142,7 @@ TECkit_Compile(char* txt, UInt32 len, Byte doCompression, TECkit_ErrorFn errFunc
 {
 	TECkit_Status	result = kStatus_CompilationFailed;
 	try {
-		Compiler*	cmp = new Compiler(txt, len, kForm_Unspecified, static_cast<bool>(doCompression), false, errFunc, userData);
+		Compiler*	cmp = new Compiler(txt, len, kForm_Unspecified, bool(doCompression), false, errFunc, userData);
 		cmp->GetCompiledTable(*outTable, *outLen);
 		if (*outTable == 0)
 			result = kStatus_CompilationFailed;
@@ -628,7 +628,7 @@ Compiler::Compiler(const char* txt, UInt32 len, char inForm, bool cmp, bool genX
 		errorState = false;
 
 		string32::const_iterator i;
-		switch (static_cast<int>(tok.type)) {
+		switch (int(tok.type)) {
 			default:
 				Error("this can't happen!");
 				break;
@@ -771,7 +771,7 @@ Compiler::Compiler(const char* txt, UInt32 len, char inForm, bool cmp, bool genX
 			case '^':
 				// negation can only apply to a few things:
 				GetNextToken();
-				switch (static_cast<int>(tok.type)) {
+				switch (int(tok.type)) {
 					case tok_Number:
 						AppendLiteral(tok.val, true);
 						break;
@@ -1129,7 +1129,7 @@ Compiler::Compiler(const char* txt, UInt32 len, char inForm, bool cmp, bool genX
 					bool	ellipsisOK = false;
 					while (tok.type != ')' && tok.type != tok_Newline) {
 						GetNextToken();
-						switch (static_cast<int>(tok.type)) {
+						switch (int(tok.type)) {
 							case tok_USV:
 								if (classType == 'B') {
 									Error("can't use Unicode value in byte encoding");
@@ -1500,7 +1500,7 @@ Compiler::asUTF8(const string32 s)
 		} else {					bytesToWrite = 2;
 									c = 0x0000fffd;
 		};
-		rval.append(static_cast<size_t>(bytesToWrite), 0);
+		rval.append(size_t(bytesToWrite), 0);
 		int index = rval.length();
 		switch (bytesToWrite) {	/* note: code falls through cases! */
 			case 4:	rval[--index] = (c | byteMark) & byteMask; c >>= 6;
@@ -1946,11 +1946,11 @@ Compiler::GetNextToken()
 			case '/':
 			case '=':
 			case '@':
-				tok.type = static_cast<tokenType>(currCh);
+				tok.type = tokenType(currCh);
 				return true;
 	
 			case '<':
-				tok.type = static_cast<tokenType>('<');
+				tok.type = tokenType('<');
 				if (textPtr < textEnd) {
 					if ((currCh = getChar()) == '>')
 						tok.type = tok_Map;
@@ -1960,7 +1960,7 @@ Compiler::GetNextToken()
 				return true;
 	
 			case '.':
-				tok.type = static_cast<tokenType>('.');
+				tok.type = tokenType('.');
 				if (textPtr < textEnd) {
 					if ((currCh = getChar()) == '.')
 						tok.type = tok_Ellipsis;
@@ -1978,7 +1978,7 @@ Compiler::GetNextToken()
 						goto DEFAULT;
 					}
 				}
-				tok.type = static_cast<tokenType>('_');
+				tok.type = tokenType('_');
 				return true;
 			
 			case '0':
@@ -3067,19 +3067,19 @@ Compiler::addToCharMap(UInt32 ch, UInt16 index)
 	UInt8	page = (ch & 0x00ffff) >> 8;
 	if (buildVars.planeMap.size() <= plane)
 		buildVars.planeMap.resize(plane + 1, 0xff);
-	if (static_cast<UInt8>(buildVars.planeMap[plane]) == 0xff) {
+	if (UInt8(buildVars.planeMap[plane]) == 0xff) {
 		buildVars.planeMap[plane] = buildVars.pageMaps.size();
 		buildVars.pageMaps.resize(buildVars.pageMaps.size() + 1);
 		buildVars.pageMaps.back().resize(256, 0xff);
 	}
 	UInt8	planeIndex = buildVars.planeMap[plane];
 	string&	pageMap = buildVars.pageMaps[planeIndex];
-	if (static_cast<UInt8>(pageMap[page]) == 0xff) {
+	if (UInt8(pageMap[page]) == 0xff) {
 		pageMap[page] = buildVars.charMaps.size();
 		buildVars.charMaps.resize(buildVars.charMaps.size() + 1);
 		buildVars.charMaps.back().resize(256);
 	}
-	vector<UInt16>&	charMap = buildVars.charMaps[static_cast<UInt8>(pageMap[page])];
+	vector<UInt16>&	charMap = buildVars.charMaps[UInt8(pageMap[page])];
 	charMap[ch & 0x0000ff] = index;
 }
 
@@ -3305,7 +3305,7 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 							
 							case kMatchElem_Type_Copy:
 								// should only occur in UU table
-								if (t > static_cast<int>(rule.matchStr.size())) {
+								if (t > int(rule.matchStr.size())) {
 									Error("no corresponding item for copy", 0, rule.lineNumber);
 									goto ERR_FOUND;
 								}
@@ -3336,7 +3336,7 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 									break;
 
 								case kMatchElem_Type_Class:
-									if (t > static_cast<int>(rule.matchStr.size())) {
+									if (t > int(rule.matchStr.size())) {
 										Error("no corresponding item for class replacement", 0, rule.lineNumber);
 										goto ERR_FOUND;
 									}
@@ -3368,7 +3368,7 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 
 								case kMatchElem_Type_Copy:
 									// should only occur in BB table
-									if (t > static_cast<int>(rule.matchStr.size())) {
+									if (t > int(rule.matchStr.size())) {
 										Error("no corresponding item for copy", 0, rule.lineNumber);
 										goto ERR_FOUND;
 									}
@@ -3462,13 +3462,13 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 			buildVars.planeMap.resize(17, 0xff);
 			for (i = 0; i < buildVars.planeMap.size(); ++i)
 				appendToTable(table, buildVars.planeMap[i]);
-			appendToTable(table, static_cast<UInt8>(buildVars.pageMaps.size()));
+			appendToTable(table, UInt8(buildVars.pageMaps.size()));
 			align(table, 4);
 		}
 
 		for (i = 0; i < buildVars.pageMaps.size(); ++i)
 			for (j = 0; j < buildVars.pageMaps[i].size(); ++j)
-				appendToTable(table, static_cast<UInt8>(buildVars.pageMaps[i][j]));
+				appendToTable(table, UInt8(buildVars.pageMaps[i][j]));
 		align(table, 4);
 
 		for (i = 0; i < buildVars.charMaps.size(); ++i)
@@ -3513,17 +3513,17 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 						sortedClass.erase(sortedClass.begin() + j);
 			}
 
-			appendToTable(classes, static_cast<UInt32>(sortedClass.size()));
+			appendToTable(classes, UInt32(sortedClass.size()));
 			if (fromUni)
 				if (currentPass.supplementaryChars)
 					for (Class::iterator x = sortedClass.begin(); x != sortedClass.end(); ++x)
 						appendToTable(classes, *x);
 				else
 					for (Class::iterator x = sortedClass.begin(); x != sortedClass.end(); ++x)
-						appendToTable(classes, static_cast<UInt16>(*x));
+						appendToTable(classes, UInt16(*x));
 			else
 				for (Class::iterator x = sortedClass.begin(); x != sortedClass.end(); ++x)
-					appendToTable(classes, static_cast<UInt8>(*x));
+					appendToTable(classes, UInt8(*x));
 			align(classes, 4);
 		}
 		// copy the real classOffsets into the table
@@ -3561,17 +3561,17 @@ Compiler::buildTable(vector<Rule>& rules, bool fromUni, bool toUni, string& tabl
 						sortedClass.erase(sortedClass.begin() + j);
 			}
 
-			appendToTable(classes, static_cast<UInt32>(sortedClass.size()));
+			appendToTable(classes, UInt32(sortedClass.size()));
 			if (toUni)
 				if (currentPass.supplementaryChars)
 					for (vector<Member>::iterator x = sortedClass.begin(); x != sortedClass.end(); ++x)
 						appendToTable(classes, x->value);
 				else
 					for (vector<Member>::iterator x = sortedClass.begin(); x != sortedClass.end(); ++x)
-						appendToTable(classes, static_cast<UInt16>(x->value));
+						appendToTable(classes, UInt16(x->value));
 			else
 				for (vector<Member>::iterator x = sortedClass.begin(); x != sortedClass.end(); ++x)
-					appendToTable(classes, static_cast<UInt8>(x->value));
+					appendToTable(classes, UInt8(x->value));
 			align(classes, 4);
 		}
 		// copy the real classOffsets into the table

--- a/source/Compiler.h
+++ b/source/Compiler.h
@@ -274,7 +274,7 @@ protected:
 	bool			GetNextToken();
 	bool			ExpectToken(tokenType type, const char* errMsg);
 	bool			ExpectToken(char c, const char* errMsg)
-						{ return ExpectToken(static_cast<tokenType>(c), errMsg); }
+						{ return ExpectToken(tokenType(c), errMsg); }
 	void			Error(const char* errMsg, const char* s = 0, UInt32 line = 0xffffffff);
 	void			StartDefaultPass();
 	void			AppendLiteral(UInt32 val, bool negate = false);

--- a/source/Compiler.h
+++ b/source/Compiler.h
@@ -274,7 +274,7 @@ protected:
 	bool			GetNextToken();
 	bool			ExpectToken(tokenType type, const char* errMsg);
 	bool			ExpectToken(char c, const char* errMsg)
-						{ return ExpectToken((tokenType)c, errMsg); }
+						{ return ExpectToken(static_cast<tokenType>(c), errMsg); }
 	void			Error(const char* errMsg, const char* s = 0, UInt32 line = 0xffffffff);
 	void			StartDefaultPass();
 	void			AppendLiteral(UInt32 val, bool negate = false);
@@ -314,12 +314,11 @@ protected:
 	void			appendToTable(string& s, const char* ptr, UInt32 len);
 	template <class T>
 		void		appendToTable(string& table, T x) {
+			const char*	xp = reinterpret_cast<const char*>(&x);
 #ifdef WORDS_BIGENDIAN
-			const char*	xp = (const char*)&x;
 			table.append(xp, sizeof(x));
 #else
 			/* split into separate statements to work around VC++6 problems */
- 			const char*	xp = (const char*)&x;
  			xp = xp + sizeof(T);
  			for (unsigned int i = 0; i < sizeof(T); ++i) {
 				xp = xp - 1;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -418,12 +418,12 @@ Pass::Pass(const TableHeader* inTable, Converter* cnv)
 	bSupplementaryChars	= (READ(tableHeader->flags) & kTableFlags_Supplementary) != 0;
 
 	numPageMaps = 1;
-	pageBase		= (const Byte*)tableHeader + READ(tableHeader->pageBase);
-	lookupBase		= (const Lookup*)((const Byte*)tableHeader + READ(tableHeader->lookupBase));
-	matchClassBase	= (const Byte*)tableHeader + READ(tableHeader->matchClassBase);
-	repClassBase	= (const Byte*)tableHeader + READ(tableHeader->repClassBase);
-	stringListBase	= (const Byte*)tableHeader + READ(tableHeader->stringListBase);
-	stringRuleData	= (const Byte*)tableHeader + READ(tableHeader->stringRuleData);
+	pageBase		= reinterpret_cast<const Byte*>(tableHeader) + READ(tableHeader->pageBase);
+	lookupBase		= reinterpret_cast<const Lookup*>(reinterpret_cast<const Byte*>(tableHeader) + READ(tableHeader->lookupBase));
+	matchClassBase	= reinterpret_cast<const Byte*>(tableHeader) + READ(tableHeader->matchClassBase);
+	repClassBase	= reinterpret_cast<const Byte*>(tableHeader) + READ(tableHeader->repClassBase);
+	stringListBase	= reinterpret_cast<const Byte*>(tableHeader) + READ(tableHeader->stringListBase);
+	stringRuleData	= reinterpret_cast<const Byte*>(tableHeader) + READ(tableHeader->stringRuleData);
 
 	if (bInputIsUnicode && bSupplementaryChars) {
 		// support supplementary plane chars
@@ -598,7 +598,7 @@ binary_search(const T* array, UInt32 count, UInt32 value)
 long
 Pass::classMatch(UInt32 classNumber, UInt32 inChar) const
 {
-	const UInt32*	classPtr = (const UInt32*)(matchClassBase + READ(*((const UInt32*)matchClassBase + classNumber)));
+	const UInt32*	classPtr = reinterpret_cast<const UInt32*>(matchClassBase + READ(*(reinterpret_cast<const UInt32*>(matchClassBase) + classNumber)));
 	UInt32			memberCount = READ(*classPtr++);
 	if (bInputIsUnicode) {
 		if (bSupplementaryChars) {
@@ -609,16 +609,16 @@ Pass::classMatch(UInt32 classNumber, UInt32 inChar) const
 		}
 		else {
 			// classes are 16-bit
-			const UInt16*	p = binary_search((const UInt16*)classPtr, memberCount, inChar);
+			const UInt16*	p = binary_search(reinterpret_cast<const UInt16*>(classPtr), memberCount, inChar);
 			if (READ(*p) == inChar)
-				return p - (const UInt16*)classPtr;
+				return p - reinterpret_cast<const UInt16*>(classPtr);
 		}
 	}
 	else {
 		// classes are 8-bit
-		const UInt8*	p = binary_search((const UInt8*)classPtr, memberCount, inChar);
+		const UInt8*	p = binary_search(reinterpret_cast<const UInt8*>(classPtr), memberCount, inChar);
 		if (READ(*p) == inChar)
-			return p - (const UInt8*)classPtr;
+			return p - reinterpret_cast<const UInt8*>(classPtr);
 	}
 	return -1;
 }
@@ -626,16 +626,16 @@ Pass::classMatch(UInt32 classNumber, UInt32 inChar) const
 UInt32
 Pass::repClassMember(UInt32 classNumber, UInt32 index) const
 {
-	const UInt32*	classPtr = (const UInt32*)(repClassBase + READ(*((const UInt32*)repClassBase + classNumber)));
+	const UInt32*	classPtr = reinterpret_cast<const UInt32*>(repClassBase + READ(*(reinterpret_cast<const UInt32*>(repClassBase) + classNumber)));
 	UInt32			memberCount = READ(*classPtr++);
 	if (index < memberCount)
 		if (bOutputIsUnicode)
 			if (bSupplementaryChars)
 				return READ(classPtr[index]);
 			else
-				return READ(((const UInt16*)classPtr)[index]);
+				return READ(reinterpret_cast<const UInt16*>(classPtr)[index]);
 		else {
-			return READ(((const UInt8*)classPtr)[index]);
+			return READ(reinterpret_cast<const UInt8*>(classPtr)[index]);
 		}
 	else
 		return 0;	// this can't happen if the compiler is right!
@@ -1015,7 +1015,7 @@ Pass::DoMapping()
 	if (bInputIsUnicode) {
 		// Unicode lookup
 		UInt16	charIndex = 0;
-		if ((const UInt8*)lookupBase == pageBase) {
+		if (reinterpret_cast<const UInt8*>(lookupBase) == pageBase) {
 			// leave charIndex == 0 : pass with no rules
 		}
 		else {
@@ -1023,7 +1023,7 @@ Pass::DoMapping()
 			const UInt8*	pageMap = 0;
 			if (bSupplementaryChars) {
 				if ((plane < 17) && (READ(planeMap[plane]) != 0xff)) {
-					pageMap = (const UInt8*)(pageBase + 256 * READ(planeMap[plane]));
+					pageMap = reinterpret_cast<const UInt8*>(pageBase + 256 * READ(planeMap[plane]));
 					goto GOT_PAGE_MAP;
 				}
 			}
@@ -1032,7 +1032,7 @@ Pass::DoMapping()
 			GOT_PAGE_MAP:
 				UInt8	page = (inChar >> 8) & 0xff;
 				if (READ(pageMap[page]) != 0xff) {
-					const UInt16*	charMapBase = (const UInt16*)(pageBase + 256 * numPageMaps);
+					const UInt16*	charMapBase = reinterpret_cast<const UInt16*>(pageBase + 256 * numPageMaps);
 					const UInt16*	charMap = charMapBase + 256 * READ(pageMap[page]);
 					charIndex = READ(charMap[inChar & 0xff]);
 				}
@@ -1042,7 +1042,7 @@ Pass::DoMapping()
 	}
 	else {
 		// byte-oriented lookup
-		if (pageBase != (const Byte*)tableHeader) {
+		if (pageBase != reinterpret_cast<const Byte*>(tableHeader)) {
 			// dbcsPage present
 			long	pageNumber = READ(pageBase[inChar]);
 			if (pageNumber == 0)
@@ -1072,14 +1072,14 @@ Pass::DoMapping()
 	UInt8	ruleType = READ(lookup->rules.type);
 	if (ruleType == kLookupType_StringRules || (ruleType & kLookupType_RuleTypeMask) == kLookupType_ExtStringRules) {
 		// process string rule list
-		const UInt32*	ruleList = (const UInt32*)stringListBase + READ(lookup->rules.ruleIndex);
+		const UInt32*	ruleList = reinterpret_cast<const UInt32*>(stringListBase) + READ(lookup->rules.ruleIndex);
 		bool			matched = false;
 		bool			allowInsertion = true;
 		int ruleCount = READ(lookup->rules.ruleCount);
 		if ((ruleType & kLookupType_RuleTypeMask) == kLookupType_ExtStringRules)
 			ruleCount += 256 * (ruleType & kLookupType_ExtRuleCountMask);
 		for ( ; ruleCount > 0; --ruleCount) {
-			const StringRule*	rule = (const StringRule*)(stringRuleData + READ(*ruleList));
+			const StringRule*	rule = reinterpret_cast<const StringRule*>(stringRuleData + READ(*ruleList));
 #ifdef TRACING
 if (traceLevel > 0) {
 	cerr << "** trying match: ";
@@ -1093,7 +1093,7 @@ if (traceLevel > 0) {
 			if (matchElems == 0 && allowInsertion == false)
 				continue;
 			patternLength = matchElems + READ(rule->postLength);
-			pattern = (MatchElem*)(rule + 1);	// point past the defined struct for the rule header
+			pattern = reinterpret_cast<const MatchElem*>(rule + 1);	// point past the defined struct for the rule header
 			direction = 1;
 			infoLimit = matchElems;
 
@@ -1134,7 +1134,7 @@ if (traceLevel > 0) {
 	cerr << "** GENERATES:";
 }
 #endif
-					const RepElem*	r = (const RepElem*)(pattern + patternLength);
+					const RepElem*	r = reinterpret_cast<const RepElem*>(pattern + patternLength);
 					for (int i = 0; i < READ(rule->repLength); ++i, ++r) {
 #ifdef TRACING
 if (traceLevel > 0)
@@ -1307,11 +1307,11 @@ Converter::Converter(const Byte* inTable, UInt32 inTableSize, bool inForward,
 	finalStage = this;
 	UInt16	normForm = 0;
 	if (inTable != 0) {
-		const FileHeader*	fh = (const FileHeader*)inTable;
+		const FileHeader*	fh = reinterpret_cast<const FileHeader*>(inTable);
 		if (READ(fh->type) == kMagicNumberCmp) {
 			// the table is compressed; allocate a new buffer and decompress
 			unsigned long	uncompressedLen = READ(fh->version);
-			table = (Byte*)malloc(uncompressedLen);
+			table = static_cast<Byte*>(malloc(uncompressedLen));
 			if (table == 0) {
 				status = kStatus_OutOfMemory;
 				return;
@@ -1321,7 +1321,7 @@ Converter::Converter(const Byte* inTable, UInt32 inTableSize, bool inForward,
 				status = kStatus_InvalidMapping;
 				return;
 			}
-			fh = (const FileHeader*)table;
+			fh = reinterpret_cast<const FileHeader*>(table);
 		}
 		
 		if (READ(fh->type) != kMagicNumber) {
@@ -1334,7 +1334,7 @@ Converter::Converter(const Byte* inTable, UInt32 inTableSize, bool inForward,
 		}
 
 		if (table == 0) {
-			table = (Byte*)malloc(inTableSize);
+			table = static_cast<Byte*>(malloc(inTableSize));
 			if (table == 0) {
 				status = kStatus_OutOfMemory;
 				return;
@@ -1342,8 +1342,8 @@ Converter::Converter(const Byte* inTable, UInt32 inTableSize, bool inForward,
 			memcpy(table, inTable, inTableSize);
 		}
 
-		fh = (const FileHeader*)table;
-		const UInt32*	nameOffsets = (const UInt32*)(table + sizeof(FileHeader));
+		fh = reinterpret_cast<const FileHeader*>(table);
+		const UInt32*	nameOffsets = reinterpret_cast<const UInt32*>(table + sizeof(FileHeader));
 		const UInt32*	tableBase = nameOffsets + READ(fh->numNames);
 		UInt32			numTables = READ(fh->numFwdTables);
 		if (!forward) {
@@ -1398,7 +1398,7 @@ Converter::Converter(const Byte* inTable, UInt32 inTableSize, bool inForward,
 
 		// create the processing pipeline
 		for (UInt32 i = 0; i < numTables; ++i) {
-			const TableHeader*	t = (const TableHeader*)(table + READ(tableBase[i]));
+			const TableHeader*	t = reinterpret_cast<const TableHeader*>(table + READ(tableBase[i]));
 			Stage*	p = 0;
 			switch (READ(t->type)) {
 				case kTableType_BB:
@@ -1708,7 +1708,7 @@ Converter::IsForward() const
 void
 Converter::GetFlags(UInt32& sourceFlags, UInt32& targetFlags) const
 {
-	const FileHeader*	fh = (const FileHeader*)table;
+	const FileHeader*	fh = reinterpret_cast<const FileHeader*>(table);
 	if (forward) {
 		sourceFlags = READ(fh->formFlagsLHS);
 		targetFlags = READ(fh->formFlagsRHS);
@@ -1722,13 +1722,13 @@ Converter::GetFlags(UInt32& sourceFlags, UInt32& targetFlags) const
 static bool
 getNamePtrFromTable(const Byte* table, UInt16 nameID, const Byte*& outNamePtr, UInt32& outNameLen)
 {
-	const FileHeader*	fh = (const FileHeader*)table;
-	const UInt32*		nameOffsets = (const UInt32*)(table + sizeof(FileHeader));
+	const FileHeader*	fh = reinterpret_cast<const FileHeader*>(table);
+	const UInt32*		nameOffsets = reinterpret_cast<const UInt32*>(table + sizeof(FileHeader));
 	for (UInt32 i = 0; i < READ(fh->numNames); ++i) {
-		const NameRec*	n = (const NameRec*)(table + READ(nameOffsets[i]));
+		const NameRec*	n = reinterpret_cast<const NameRec*>(table + READ(nameOffsets[i]));
 		if (READ(n->nameID) == nameID) {
 			outNameLen = READ(n->nameLength);
-			outNamePtr = (const Byte*)n + sizeof(NameRec);
+			outNamePtr = reinterpret_cast<const Byte*>(n) + sizeof(NameRec);
 			return true;
 		}
 	}
@@ -1935,7 +1935,7 @@ Converter::Validate(const Converter* cnv)
 	if (cnv->status != kStatus_NoError)
 		return false;
 	if (cnv->table != 0) {
-		const FileHeader*	fh = (const FileHeader*)cnv->table;
+		const FileHeader*	fh = reinterpret_cast<const FileHeader*>(cnv->table);
 		if (READ(fh->type) != kMagicNumber)
 			return false;
 	}
@@ -1963,7 +1963,7 @@ TECkit_CreateConverter(
 		cnv = new Converter(mapping, mappingSize, mapForward, inputForm, outputForm);
 		status = cnv->creationStatus();
 		if (status == kStatus_NoError)
-			*converter = (TECkit_Converter)cnv;
+			*converter = reinterpret_cast<TECkit_Converter>(cnv);
 		else
 			delete cnv;
 	}
@@ -1982,7 +1982,7 @@ TECkit_DisposeConverter(
 	TECkit_Converter	converter)
 {
 	TECkit_Status	status = kStatus_NoError;
-	Converter*	cnv = (Converter*)converter;
+	Converter*	cnv = reinterpret_cast<Converter*>(converter);
 	if (!Converter::Validate(cnv))
 		status = kStatus_InvalidConverter;
 	else
@@ -2000,7 +2000,7 @@ TECkit_GetConverterName(
 	UInt32*				nameLength)
 {
 	TECkit_Status	status = kStatus_NoError;
-	Converter*	cnv = (Converter*)converter;
+	Converter*	cnv = reinterpret_cast<Converter*>(converter);
 	if (!Converter::Validate(cnv))
 		status = kStatus_InvalidConverter;
 	else {
@@ -2024,7 +2024,7 @@ TECkit_GetConverterFlags(
 	UInt32*				targetFlags)
 {
 	TECkit_Status	status = kStatus_NoError;
-	Converter*	cnv = (Converter*)converter;
+	Converter*	cnv = reinterpret_cast<Converter*>(converter);
 	if (!Converter::Validate(cnv))
 		status = kStatus_InvalidConverter;
 	else
@@ -2038,7 +2038,7 @@ TECkit_ResetConverter(
 	TECkit_Converter	converter)
 {
 	TECkit_Status	status = kStatus_NoError;
-	Converter*	cnv = (Converter*)converter;
+	Converter*	cnv = reinterpret_cast<Converter*>(converter);
 	if (!Converter::Validate(cnv))
 		status = kStatus_InvalidConverter;
 	else
@@ -2060,7 +2060,7 @@ TECkit_ConvertBufferOpt(
 	UInt32*				lookaheadCount)
 {
 	TECkit_Status	status = kStatus_NoError;
-	Converter*	cnv = (Converter*)converter;
+	Converter*	cnv = reinterpret_cast<Converter*>(converter);
 	if (!Converter::Validate(cnv))
 		status = kStatus_InvalidConverter;
 	else
@@ -2095,7 +2095,7 @@ TECkit_FlushOpt(
 	UInt32*				lookaheadCount)
 {
 	TECkit_Status	status = kStatus_NoError;
-	Converter*	cnv = (Converter*)converter;
+	Converter*	cnv = reinterpret_cast<Converter*>(converter);
 	if (!Converter::Validate(cnv))
 		status = kStatus_InvalidConverter;
 	else
@@ -2127,12 +2127,12 @@ TECkit_GetMappingFlags(
 	if (mapping == 0)
 		status = kStatus_InvalidMapping;
 	else {
-		const FileHeader*	fh = (const FileHeader*)mapping;
+		const FileHeader*	fh = reinterpret_cast<const FileHeader*>(mapping);
 		FileHeader			header;
 		if (READ(fh->type) == kMagicNumberCmp) {
 			// compressed mapping, so we need to decompress enough of it to read the flags
 			unsigned long	uncompressedLen = sizeof(FileHeader);
-			int	result = uncompress((Byte*)&header, &uncompressedLen, mapping + 2 * sizeof(UInt32), mappingSize - 2 * sizeof(UInt32));
+			int	result = uncompress(reinterpret_cast<Byte*>(&header), &uncompressedLen, mapping + 2 * sizeof(UInt32), mappingSize - 2 * sizeof(UInt32));
 			if (result != Z_BUF_ERROR)
 				status = kStatus_InvalidMapping;
 			fh = &header;
@@ -2166,13 +2166,13 @@ TECkit_GetMappingName(
 	if (mapping == 0)
 		status = kStatus_InvalidMapping;
 	else {
-		const FileHeader*	fh = (const FileHeader*)mapping;
+		const FileHeader*	fh = reinterpret_cast<const FileHeader*>(mapping);
 		FileHeader			header;
 		if (READ(fh->type) == kMagicNumberCmp) {
 			// compressed mapping, so we need to decompress the fixed header to read the headerLength field,
 			// and then decompress the complete header to get the names
 			unsigned long	uncompressedLen = sizeof(FileHeader);
-			int	result = uncompress((Byte*)&header, &uncompressedLen, mapping + 2 * sizeof(UInt32), mappingSize - 2 * sizeof(UInt32));
+			int	result = uncompress(reinterpret_cast<Byte*>(&header), &uncompressedLen, mapping + 2 * sizeof(UInt32), mappingSize - 2 * sizeof(UInt32));
 			if (result != Z_BUF_ERROR)
 				status = kStatus_InvalidMapping;
 			else {
@@ -2182,10 +2182,10 @@ TECkit_GetMappingName(
 				if (buf == 0)
 					status = kStatus_OutOfMemory;
 				else {
-					result = uncompress((Byte*)buf, &uncompressedLen, mapping + 2 * sizeof(UInt32), mappingSize - 2 * sizeof(UInt32));
+					result = uncompress(static_cast<Byte*>(buf), &uncompressedLen, mapping + 2 * sizeof(UInt32), mappingSize - 2 * sizeof(UInt32));
 					if (result != Z_BUF_ERROR)
 						status = kStatus_InvalidMapping;
-					fh = (const FileHeader*)buf;
+					fh = static_cast<const FileHeader*>(buf);
 				}
 			}
 		}
@@ -2194,7 +2194,7 @@ TECkit_GetMappingName(
 				status = kStatus_BadMappingVersion;
 			else {
 				const Byte*	namePtr;
-				if (getNamePtrFromTable((Byte*)fh, nameID, namePtr, *nameLength)) {
+				if (getNamePtrFromTable(reinterpret_cast<const Byte*>(fh), nameID, namePtr, *nameLength)) {
 					UInt16	copyBytes = *nameLength < bufferSize ? *nameLength : bufferSize;
 					if (copyBytes > 0)
 						memcpy(nameBuffer, namePtr, copyBytes);

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -117,7 +117,7 @@ protected:
 
 	UInt32				match(int index, int repeats, int textLoc);
 								// returns 0 for no match, 1 for match, or kNeedMoreInput/kInvalidChar
-	MatchElem*			pattern;
+	const MatchElem*		pattern;
 	int					patternLength;
 	int					direction;
 	MatchInfo			info[256];

--- a/source/Public-headers/TECkit_Compiler.h
+++ b/source/Public-headers/TECkit_Compiler.h
@@ -56,7 +56,7 @@ extern "C" {
 #define kCompilerOpts_Compress	0x00000010	/* generate compressed mapping table */
 #define kCompilerOpts_XML		0x00000020	/* instead of a compiled binary table, generate an XML representation of the mapping */
 
-typedef void (CALLBACK *TECkit_ErrorFn)(void* userData, char* msg, char* param, UInt32 line);
+typedef void (CALLBACK *TECkit_ErrorFn)(void* userData, const char* msg, const char* param, UInt32 line);
 
 TECkit_Status
 WINAPI EXPORTED
@@ -75,7 +75,7 @@ WINAPI EXPORTED
 TECkit_GetCompilerVersion();
 
 /* new APIs for looking up Unicode names (as NUL-terminated C strings) */
-char*
+const char*
 WINAPI EXPORTED
 TECkit_GetUnicodeName(UInt32 usv);
 	/* returns the Unicode name of usv, if available, else NULL */

--- a/source/Public-headers/TECkit_Compiler.h
+++ b/source/Public-headers/TECkit_Compiler.h
@@ -56,7 +56,7 @@ extern "C" {
 #define kCompilerOpts_Compress	0x00000010	/* generate compressed mapping table */
 #define kCompilerOpts_XML		0x00000020	/* instead of a compiled binary table, generate an XML representation of the mapping */
 
-typedef void (CALLBACK *TECkit_ErrorFn)(void* userData, const char* msg, const char* param, UInt32 line);
+typedef void (CALLBACK *TECkit_ErrorFn)(void* userData, char* msg, char* param, UInt32 line);
 
 TECkit_Status
 WINAPI EXPORTED
@@ -75,7 +75,7 @@ WINAPI EXPORTED
 TECkit_GetCompilerVersion();
 
 /* new APIs for looking up Unicode names (as NUL-terminated C strings) */
-const char*
+char*
 WINAPI EXPORTED
 TECkit_GetUnicodeName(UInt32 usv);
 	/* returns the Unicode name of usv, if available, else NULL */

--- a/source/Sample-tools/TECkit_Compile.cpp
+++ b/source/Sample-tools/TECkit_Compile.cpp
@@ -24,13 +24,13 @@
 #endif
 
 extern "C" {
-	static void CALLBACK errFunc(void* userData, char* msg, char* param, UInt32 line);
+	static void CALLBACK errFunc(void* userData, const char* msg, const char* param, UInt32 line);
 };
 
 static
 void
 CALLBACK
-errFunc(void* /*userData*/, char* msg, char* param, UInt32 line)
+errFunc(void* /*userData*/, const char* msg, const char* param, UInt32 line)
 {
 	fprintf(stderr, "%s", msg);
 	if (param != 0)

--- a/source/Sample-tools/TECkit_Compile.cpp
+++ b/source/Sample-tools/TECkit_Compile.cpp
@@ -194,7 +194,7 @@ Usage: %s [-u] [-x] [-z] mapping_description [-o compiled_table]\n\
 			TECkit_DisposeCompiled(compiledTable);
 		}
 		else {
-			fprintf(stderr, "compilation failed: status = %d\n", static_cast<int>(status));
+			fprintf(stderr, "compilation failed: status = %d\n", int(status));
 			return 1;
 		}
 		

--- a/source/Sample-tools/TECkit_Compile.cpp
+++ b/source/Sample-tools/TECkit_Compile.cpp
@@ -24,13 +24,13 @@
 #endif
 
 extern "C" {
-	static void CALLBACK errFunc(void* userData, const char* msg, const char* param, UInt32 line);
+	static void CALLBACK errFunc(void* userData, char* msg, char* param, UInt32 line);
 };
 
 static
 void
 CALLBACK
-errFunc(void* /*userData*/, const char* msg, const char* param, UInt32 line)
+errFunc(void* /*userData*/, char* msg, char* param, UInt32 line)
 {
 	fprintf(stderr, "%s", msg);
 	if (param != 0)

--- a/source/Sample-tools/TECkit_Compile.cpp
+++ b/source/Sample-tools/TECkit_Compile.cpp
@@ -36,7 +36,7 @@ errFunc(void* /*userData*/, char* msg, char* param, UInt32 line)
 	if (param != 0)
 		fprintf(stderr, ": \"%s\"", param);
 	if (line != 0)
-		fprintf(stderr, " at line %lu", (unsigned long)line);
+		fprintf(stderr, " at line %lu", static_cast<unsigned long>(line));
 	fprintf(stderr, "\n");
 }
 
@@ -114,7 +114,7 @@ Usage: %s [-u] [-x] [-z] mapping_description [-o compiled_table]\n\
 
 	if (tecFileName == 0) {
 		int	x = strlen(mapFileName);
-		tecFileName = (char*)malloc(x + 5);
+		tecFileName = static_cast<char*>(malloc(x + 5));
 		if (tecFileName == 0)
 			return 1;	// unlikely!
 		strcpy(tecFileName, mapFileName);
@@ -143,7 +143,7 @@ Usage: %s [-u] [-x] [-z] mapping_description [-o compiled_table]\n\
 		
 		if (inFile == 0) {
 			// try adding .map
-			char*	mapFileName2 = (char*)malloc(strlen(mapFileName) + 5);
+			char*	mapFileName2 = static_cast<char*>(malloc(strlen(mapFileName) + 5));
 			if (mapFileName2 == 0)
 				return 1;
 			strcpy(mapFileName2, mapFileName);
@@ -159,7 +159,7 @@ Usage: %s [-u] [-x] [-z] mapping_description [-o compiled_table]\n\
 		len = ftell(inFile);
 		fseek(inFile, 0, SEEK_SET);
 		
-		txt = (char*)malloc(len);
+		txt = static_cast<char*>(malloc(len));
 		if (txt == 0) {
 			fprintf(stderr, "not enough memory to read mapping file\n");
 			return 1;	// not enough memory
@@ -194,7 +194,7 @@ Usage: %s [-u] [-x] [-z] mapping_description [-o compiled_table]\n\
 			TECkit_DisposeCompiled(compiledTable);
 		}
 		else {
-			fprintf(stderr, "compilation failed: status = %d\n", (int)status);
+			fprintf(stderr, "compilation failed: status = %d\n", static_cast<int>(status));
 			return 1;
 		}
 		

--- a/source/ulong_chartraits.h
+++ b/source/ulong_chartraits.h
@@ -98,7 +98,7 @@ namespace std
       { return __c1 == __c2; }
 
       static int_type 
-      eof() { return static_cast<int_type>(-1); }
+      eof() { return int_type(-1); }
 
       static int_type 
       not_eof(const int_type& __c)

--- a/source/ulong_chartraits.h
+++ b/source/ulong_chartraits.h
@@ -72,11 +72,11 @@ namespace std
 
       static char_type* 
       move(char_type* __s1, const char_type* __s2, size_t __n)
-      { return (char_type*) memmove(__s1, __s2, __n * sizeof(char_type)); }
+      { return static_cast<char_type*>(memmove(__s1, __s2, __n * sizeof(char_type))); }
 
       static char_type* 
       copy(char_type* __s1, const char_type* __s2, size_t __n)
-      { return (char_type*) memcpy(__s1, __s2, __n * sizeof(char_type)); }
+      { return static_cast<char_type*>(memcpy(__s1, __s2, __n * sizeof(char_type))); }
 
       static char_type* 
       assign(char_type* __s, size_t __n, char_type __a)


### PR DESCRIPTION
This changes C-style casts to safer C++-style casts. These warnings were found with `clang` and the following:

```
$ ./configure CXXFLAGS="-Werror -Wold-style-cast"
```

1. Where possible, I use `static_cast`. This is the safest option.
2. Where required, I used `reinterpret_cast`. This was mainly (if not exclusively) used for pointer casts, where pointer manipulation was being done.
3. If necessary, I used `const_cast`. In a few places, it was clear that this was necessary; in others, it was not.

    `TECkit_GetUnicodeName` and `TECkit_GetTECkitName` return `char *`. I wonder why not return `const char *`.

    In `errorFunction`, it seems like the callback type should have arguments of type `const char *` instead of `char *`. I didn't change it in case it might break something of which I am not aware.

There were a few places where casts were not needed and removed. In one place, I added `const` to a member variable and removed a cast.

I realize this may be controversial change. It is certainly something that should be reviewed carefully and tested. In particular, I don't know what effect this has on Windows building.

As a follow-up, I believe it would be good to fix the warnings reported by `-Wsign-conversion -Wconversion -Wshorten-64-to-32`. But I think that should only happen if you're happy with this change.