### PR TITLE
Use out-of-tree build for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ matrix:
 
 script:
   - ./autogen.sh
-  - ./configure
-  - make
-  - sudo make install
-  - cd test; ./dotests.pl
+  - |
+    mkdir build &&
+    cd build &&
+    ../configure &&
+    make &&
+    (make check || cat build/test/dotests.pl.log) &&
+    sudo make install


### PR DESCRIPTION
This adapts the `.travis.yml` to @neilmayhew's suggestion of an out-of-tree build at https://github.com/silnrsi/teckit/pull/9#discussion_r229111297.