### PR TITLE
Fix some -Wsign-conversion warnings

### DIFF
--- a/SFconv/ushort_chartraits.h
+++ b/SFconv/ushort_chartraits.h
@@ -51,7 +51,7 @@ namespace std
       { 
         const char_type* __p = __s; 
         while (*__p) ++__p; 
-        return (__p - __s); 
+        return static_cast<size_t>(__p - __s);
       }
 
       static const char_type* 

--- a/source/Compiler.h
+++ b/source/Compiler.h
@@ -283,7 +283,7 @@ protected:
 	void			AppendToRule(const Item& item);
 	bool			tagExists(bool rhs, const string& tag);
 	void			AssignTag(const string& tag);
-	void			SetMinMax(int repeatMin, int repeatMax);
+	void			SetMinMax(UInt32 repeatMin, UInt32 repeatMax);
 	void			FinishPass();
 	string			asUTF8(const string32 s);
 	void			ReadNameString(UInt16 nameID);
@@ -306,7 +306,7 @@ protected:
 	long			uniClassIndex(UInt32 charCode, UInt32 classIndex);
 	long			byteClassIndex(UInt8 charCode, UInt32 classIndex);
 	bool			isSingleCharRule(const Rule& rule);
-	void			appendMatchElem(string& packedRule, Item& item, int index,
+	void			appendMatchElem(string& packedRule, Item& item, unsigned int index,
 									vector<MatClass>& matchClasses);
 	void			appendReplaceElem(string& packedRule, Item& item,
 									vector<Item>& matchStr, vector<RepClass>& repClasses);
@@ -327,7 +327,7 @@ protected:
 	}
 
 	vector<Item>	reverseContext(const vector<Item>& ctx);
-	void			align(string& table, int alignment);
+	void			align(string& table, string::size_type alignment);
 	
 	void			xmlOut(const char* s);
 	void			xmlOut(const string& s);

--- a/source/Public-headers/TECkit_Engine.h
+++ b/source/Public-headers/TECkit_Engine.h
@@ -31,16 +31,16 @@ Description:
 #include "TECkit_Common.h"
 
 /* formFlags bits for normalization; if none are set, then this side of the mapping is normalization-form-agnostic on input, and may generate an unspecified mixture */
-#define kFlags_ExpectsNFC		0x00000001	/* expects fully composed text (NC) */
-#define kFlags_ExpectsNFD		0x00000002	/* expects fully decomposed text (NCD) */
-#define kFlags_GeneratesNFC		0x00000004	/* generates fully composed text (NC) */
-#define kFlags_GeneratesNFD		0x00000008	/* generates fully decomposed text (NCD) */
+#define kFlags_ExpectsNFC		0x00000001U	/* expects fully composed text (NC) */
+#define kFlags_ExpectsNFD		0x00000002U	/* expects fully decomposed text (NCD) */
+#define kFlags_GeneratesNFC		0x00000004U	/* generates fully composed text (NC) */
+#define kFlags_GeneratesNFD		0x00000008U	/* generates fully decomposed text (NCD) */
 
 /* if VisualOrder is set, this side of the mapping deals with visual-order rather than logical-order text (only relevant for bidi scripts) */
-#define kFlags_VisualOrder		0x00008000	/* visual rather than logical order */
+#define kFlags_VisualOrder		0x00008000U	/* visual rather than logical order */
 
 /* if Unicode is set, the encoding is Unicode on this side of the mapping */
-#define kFlags_Unicode			0x00010000	/* this is Unicode rather than a byte encoding */
+#define kFlags_Unicode			0x00010000U	/* this is Unicode rather than a byte encoding */
 
 /* required names */
 #define kNameID_LHS_Name		0		/* "source" or LHS encoding name, e.g. "SIL-EEG_URDU-2001" */

--- a/source/ulong_chartraits.h
+++ b/source/ulong_chartraits.h
@@ -58,7 +58,7 @@ namespace std
       { 
         const char_type* __p = __s; 
         while (*__p) ++__p; 
-        return (__p - __s); 
+        return static_cast<size_t>(__p - __s);
       }
 
       static const char_type* 


### PR DESCRIPTION
Fix some warnings reported by `clang` with:

```
$ ../configure CXXFLAGS="-Wsign-conversion"; make
```

There are a lot more, but I thought it would be good to start small.

Also, I wanted to ask about these warnings in particular:

```c++
  CXX      ../source/Compiler.lo
../../lib/../source/Compiler.cpp:3300:35: warning: implicit conversion changes signedness: 'long' to 'std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >::size_type' (aka 'unsigned long')
      [-Wsign-conversion]
                                                                                WRITE(lookup[i].usv, rc[classIndex(indexToChar[i], mc)]);
                                                                                                     ~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../lib/../source/Compiler.cpp:3308:35: warning: implicit conversion changes signedness: 'long' to 'std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >::size_type' (aka 'unsigned long')
      [-Wsign-conversion]
                                                                                WRITE(lookup[i].usv, rc[classIndex(i, mc)]);
                                                                                                     ~~ ^~~~~~~~~~~~~~~~~
../../lib/../source/Compiler.cpp:3368:46: warning: implicit conversion changes signedness: 'long' to 'std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >::size_type' (aka 'unsigned long')
      [-Wsign-conversion]
                                                                                        WRITE(lookup[i].bytes.data[j], rc[classIndex(indexToChar[i], mc)]);
                                                                                                                       ~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../lib/../source/Compiler.cpp:3376:46: warning: implicit conversion changes signedness: 'long' to 'std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >::size_type' (aka 'unsigned long')
      [-Wsign-conversion]
                                                                                        WRITE(lookup[i].bytes.data[j], rc[classIndex(i, mc)]);
```

Since `long Compiler::classIndex(UInt32 charCode, const Class& classMembers) { ... }` returns -1 for an unhandled case, it seems to me that the above uses of `rc[classIndex(...)]` may need some error checking. Alternatively, it may be that `classIndex(...)` never returns -1 in these cases, but that requires a deeper understanding that I have not attempted. In the latter case, it should probably be noted anyway.