### PR TITLE
Fix Windows cross-compiling on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,6 @@ addons:
       - debhelper
       - cdbs
       # For cross-compiling Windows executables
-      - gcc-mingw-w64-i686
-      - g++-mingw-w64-i686
-      - binutils-mingw-w64-i686
-      - gcc-mingw-w64-x86-64
-      - g++-mingw-w64-x86-64
-      - binutils-mingw-w64-x86-64
+      - mingw-w64
+      - dos2unix
+      - groff

--- a/build-windows-binaries.sh
+++ b/build-windows-binaries.sh
@@ -22,7 +22,7 @@ do
     BUILD=$(../config.guess)
     set_compiler $bit
 
-    echo "build is +${BUILD}+ host is +${HOST}+ in binaries with bit +${bit}+"
+    echo "BUILD=${BUILD} HOST=${HOST} bit=${bit}"
     ../configure --build=$BUILD --host=$HOST --with-old-lib-names --without-system-zlib --enable-final --disable-dependency-tracking
     make
     make install-strip DESTDIR=`pwd`/inst

--- a/build-windows-common
+++ b/build-windows-common
@@ -7,7 +7,9 @@ find_compiler()
     # Check the various names used for mingw
     for PREFIX in "$@"
     do
-        if which $PREFIX-gcc >/dev/null
+        CC=$PREFIX-gcc
+        CXX=$PREFIX-g++
+        if which $CC > /dev/null && which $CXX > /dev/null
         then
             HOST=$PREFIX
             break


### PR DESCRIPTION
* Closes #20
* Adds CC and CXX needed for make
* Minimizes mingw package dependencies
* Adds packages needed for documentation generation