### PR TITLE
Correct indentation

### DIFF
--- a/SFconv/SFconv.cpp
+++ b/SFconv/SFconv.cpp
@@ -101,7 +101,7 @@ Utf8ToString(const char* s)
 	utf16::iterator out = buf;
 	utf8::const_iterator in  = s, 
 	                     end = s + len;
-    while (in != end && !(in.error() || out.error()))
+	while (in != end && !(in.error() || out.error()))
         *out++ = *in++;
     
 	if (in.error() || out.error()) {
@@ -109,7 +109,7 @@ Utf8ToString(const char* s)
 		exit(1);
 	}
 
-    ustring ustr(buf, out - buf);
+	ustring ustr(buf, out - buf);
 	delete[] buf;
 	return ustr;
 }


### PR DESCRIPTION
GCC 9.1.1 complains:

../SFconv/SFconv.cpp:104:5: warning: this 'while' clause does not guard... [-Wmisleading-indentation]
  104 |     while (in != end && !(in.error() || out.error()))
      |     ^~~~~
../SFconv/SFconv.cpp:107:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'while'
  107 |  if (in.error() || out.error()) {
      |  ^~

This patch fixes it.