### PR TITLE
Added ppc64le support on travis-ci 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ matrix:
       script:
         - ./autogen.sh
         - ./build-mac-binaries.sh
-
+arch:
+  - ppc64le
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
       compiler: gcc
       script:
         - ./autogen.sh
-        - ./build-linux-binaries.sh
+        - ./build-linux-binaries.sh 
     - os: linux
       dist: bionic
       script:
@@ -29,8 +29,15 @@ matrix:
       script:
         - ./autogen.sh
         - ./build-mac-binaries.sh
-arch:
-  - ppc64le
+    - os: linux 
+      dist: bionic
+      compiler: gcc
+      script:
+        - ./autogen.sh
+        - ./build-linux-binaries.sh
+
+      arch: 
+        - ppc64le
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,17 @@ matrix:
       script:
         - ./autogen.sh
         - ./build-linux-binaries.sh
-
       arch: 
         - ppc64le
+   - os: linux
+      dist: bionic
+      compiler: clang
+      script:
+        - ./autogen.sh
+        - ./build-linux-binaries.sh
+      arch:
+        - ppc64le
+
 addons:
   apt:
     packages:


### PR DESCRIPTION

Hi,
I had added ppc64le support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/ujjwalsh/teckit.

Please have a look.

Regards,
ujjwal